### PR TITLE
fix: lexical-binding must be on first line of file

### DIFF
--- a/efire.el
+++ b/efire.el
@@ -1,4 +1,4 @@
-;;; efire.el --- Use campfire from Emacs
+;;; efire.el --- Use campfire from Emacs -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  João Távora
 
@@ -646,6 +646,5 @@
 (provide 'efire)
 ;;; efire.el ends here
 ;; Local Variables:
-;; lexical-binding: t
 ;; coding: utf-8
 ;; End:


### PR DESCRIPTION
Per the Elisp manual, section 11.9.4:

  Variable: lexical-binding

    [...] Note that unlike other such variables, this one must be set in
    the first line of a file.

Without this, url-retrieve's callbacks don't have the right variables
bound, at least in emacs 24.5.1.